### PR TITLE
Update iconPicker.dart

### DIFF
--- a/lib/IconPicker/iconPicker.dart
+++ b/lib/IconPicker/iconPicker.dart
@@ -44,7 +44,7 @@ class _IconPickerState extends State<IconPicker> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       if (widget.customIconPack != null) {
         if (mounted) widget.iconController.addAll(widget.customIconPack ?? {});
       }


### PR DESCRIPTION
fix: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.